### PR TITLE
Fix checksum field

### DIFF
--- a/message.go
+++ b/message.go
@@ -84,10 +84,10 @@ func (m Message) Encode() Packet {
 	copy(raw[MESG_DATA_OFFSET:], m.Data)
 
 	checksum := MESG_TX_SYNC ^ byte(msgLen) ^ m.Id
-
-	for n := 2; n < msgLen; n++ {
+	for n := 0; n < msgLen; n++ {
 		checksum ^= m.Data[n]
 	}
+
 	raw[rawLen-1] = checksum
 	// raw[rawLen] = 0
 	// raw[rawLen+1] = 0


### PR DESCRIPTION
Fixes #3 by ensuring the same checksum calculation in `Encode()` that is done in `Checksum()`. I think the code was meant to skip 2 bytes of the raw data, not the content data. It should start on byte 0 of the content data.

Regarding the output I was getting in the issue description. The output, with this fix:

```bash
2023/12/31 02:08:39 Starting Device
2023/12/31 02:08:39 Opening USB device
2023/12/31 02:08:39 USB Device opened
2023/12/31 02:08:39 Loop Started
2023/12/31 02:08:39 Writing:  [0xA4, 0x01, 0x4A, 0x00, 0xEF]
2023/12/31 02:08:39 Read: AntMessage (0x6F) [0x20]
2023/12/31 02:08:40 Writing:  [0xA4, 0x09, 0x46, 0x00, 0xB9, 0xA5, 0x21, 0xFB, 0xBD, 0x72, 0xC3, 0x45, 0x64]
2023/12/31 02:08:40 Writing:  [0xA4, 0x03, 0x42, 0x00, 0x00, 0x01, 0xE4]
2023/12/31 02:08:40 Writing:  [0xA4, 0x05, 0x51, 0x00, 0xC2, 0x00, 0x77, 0x00, 0x45]
2023/12/31 02:08:40 Read: AntMessage (0x40) [0x00, 0x46, 0x00]
2023/12/31 02:08:40 Writing:  [0xA4, 0x02, 0x45, 0x00, 0x39, 0xDA]
2023/12/31 02:08:40 Read: AntMessage (0x40) [0x00, 0x42, 0x00]
2023/12/31 02:08:40 Writing:  [0xA4, 0x03, 0x43, 0x00, 0x00, 0x20, 0xC4]
2023/12/31 02:08:40 Writing:  [0xA4, 0x02, 0x5B, 0x00, 0x01, 0xFC]
2023/12/31 02:08:40 Read: AntMessage (0x40) [0x00, 0x51, 0x00]
2023/12/31 02:08:40 Loop stopped!
2023/12/31 02:08:40 Closing USB device
2023/12/31 02:08:40 USB Device closed
```